### PR TITLE
Update specificworker.py in peoplecounter

### DIFF
--- a/components/peopleCounter/src/specificworker.py
+++ b/components/peopleCounter/src/specificworker.py
@@ -30,8 +30,10 @@ import numpy as np
 import requests
 from imutils.video import FPS
 
-from resources.centroidtracker import CentroidTracker
-from resources.trackableobject import TrackableObject
+import sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) +"/../resources/")
+from centroidtracker import CentroidTracker
+from trackableobject import TrackableObject
 
 from genericworker import *
 from RoboCompPeopleServer import TImage


### PR DESCRIPTION
In the component PeopleCounter, we get an import error because functions are imported from the resources directory which is not there in the working directory ie src. 
This commit ensures that the python modules are imported properly from the resources directory.