### PR TITLE
Update specificworker.py in openpifpafsever

### DIFF
--- a/components/openpifpafserver/src/specificworker.py
+++ b/components/openpifpafserver/src/specificworker.py
@@ -77,6 +77,15 @@ class SpecificWorker(GenericWorker):
 			head_kernel_size = 1
 			head_padding = 0
 			head_dilation = 0
+			cross_talk = 0.0
+			two_scale = False
+			multi_scale = False
+			multi_scale_hflip = True
+			paf_th = 0.1
+			pif_th = 0.1
+			decoder_workers = None
+			experimental_decoder = False
+			extra_coupling = 0.0
 
 
 		self.args = Args()


### PR DESCRIPTION
The lines are added to `specificworker.py` in the component openpifpafserver.
These added lines are some parameters which are in the package `/openpifpaf/network/nets.py` and not specifying these values lead to errors like `File "src/openpifpafServer.py", line 108, in <module>
    worker = SpecificWorker(mprx)
  File "/home/caradmin/robocomp/components/human-detection/components/openpifpafserver/src/specificworker.py", line 39, in __init__
    self.initialize()
  File "/home/caradmin/robocomp/components/human-detection/components/openpifpafserver/src/specificworker.py", line 92, in initialize
    model, _ = nets.factory_from_args(self.args)
  File "/home/caradmin/.local/lib/python3.6/site-packages/openpifpaf/network/nets.py", line 192, in factory_from_args
    cross_talk=args.cross_talk,
AttributeError: 'Args' object has no attribute 'cross_talk'`
I initialised these parameters to the default values in from the openpifpaf package:
https://github.com/vita-epfl/openpifpaf